### PR TITLE
Moar

### DIFF
--- a/terraform/states/image-annotator/resources.tf
+++ b/terraform/states/image-annotator/resources.tf
@@ -96,15 +96,15 @@ resource "aws_instance" "staging" {
 resource "aws_route53_record" "ajl-bocoup-org_A_ajl-bocoup-org" {
   zone_id = "${data.terraform_remote_state.foundation.domain_zone_id}"
   type = "A"
-  name = "production"
+  name = "ajl"
   ttl = "1"
   records = ["${aws_instance.production.public_ip}"]
 }
 
-resource "aws_route53_record" "ajl-staging-bocoup-org_A_ajl-staging-bocoup-org" {
+resource "aws_route53_record" "ajl-bocoup-org_A_ajl-staging-bocoup-org" {
   zone_id = "${data.terraform_remote_state.foundation.domain_zone_id}"
   type = "A"
-  name = "staging"
+  name = "ajl-staging"
   ttl = "1"
   records = ["${aws_instance.staging.public_ip}"]
 }

--- a/terraform/states/image-annotator/resources.tf
+++ b/terraform/states/image-annotator/resources.tf
@@ -173,3 +173,8 @@ EOF
 resource "aws_iam_user" "backup" {
   name = "${var.name}-backup"
 }
+
+resource "aws_iam_user_policy_attachment" "backup" {
+  user = "${aws_iam_user.backup.name}"
+  policy_arn = "${aws_iam_policy.backup.arn}"
+}

--- a/terraform/states/image-annotator/resources.tf
+++ b/terraform/states/image-annotator/resources.tf
@@ -12,6 +12,10 @@ module "subnet" {
   cidr_blocks = "${var.subnet_cidr_blocks}"
 }
 
+resource "aws_s3_bucket" "backup" {
+  bucket = "image-annotator-backup"
+}
+
 resource "aws_s3_bucket" "main" {
   acl = "public-read"
   bucket = "image-annotator-assets"
@@ -78,6 +82,7 @@ resource "aws_instance" "production" {
   tags {
     "Name" = "${var.name}-production"
   }
+  iam_instance_profile = "${aws_iam_instance_profile.backup.name}"
 }
 
 resource "aws_instance" "staging" {
@@ -91,6 +96,7 @@ resource "aws_instance" "staging" {
   tags {
     "Name" = "${var.name}-staging"
   }
+  iam_instance_profile = "${aws_iam_instance_profile.backup.name}"
 }
 
 resource "aws_route53_record" "ajl-bocoup-org_A_ajl-bocoup-org" {
@@ -107,4 +113,63 @@ resource "aws_route53_record" "ajl-bocoup-org_A_ajl-staging-bocoup-org" {
   name = "ajl-staging"
   ttl = "1"
   records = ["${aws_instance.staging.public_ip}"]
+}
+
+resource "aws_iam_role" "backup" {
+  name = "${var.name}-backup"
+  path = "/"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {"AWS": "*"},
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy_attachment" "backup" {
+  name = "${var.name}-backup"
+  roles = ["${aws_iam_role.backup.name}"]
+  policy_arn = "${aws_iam_policy.backup.arn}"
+}
+
+resource "aws_iam_instance_profile" "backup" {
+  name = "${var.name}-backup"
+  roles = ["${aws_iam_role.backup.name}"]
+}
+
+
+resource "aws_iam_policy" "backup" {
+  name = "${var.name}-backup"
+  description = "Rights for backup files"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:ListAllMyBuckets",
+      "Resource": "arn:aws:s3:::*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::${aws_s3_bucket.backup.id}*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+# This user owns the access keys that allow local devs to load production backups
+resource "aws_iam_user" "backup" {
+  name = "${var.name}-backup"
 }


### PR DESCRIPTION
This adds support for a backup bucket and creates the resources
needed to grant our EC2 instances direct access to said buckets
without sharing keys (via instance profiles)