### PR TITLE
Decouple ajl.ai and bocoup.org

### DIFF
--- a/terraform/projects/ajl/dns.tf
+++ b/terraform/projects/ajl/dns.tf
@@ -43,18 +43,10 @@ resource "aws_route53_record" "ajl-ai_A_ajl-ai" {
   records = ["${aws_instance.production.public_ip}"]
 }
 
-resource "aws_route53_record" "ajl-bocoup-org_A_ajl-bocoup-org" {
-  zone_id = "${data.terraform_remote_state.foundation.domain_zone_id}"
+resource "aws_route53_record" "ajl-ai_CNAME_staging-ajl-ai" {
+  zone_id = "${aws_route53_zone.ajl-ai.id}"
   type = "A"
-  name = "ajl"
-  ttl = "1"
-  records = ["${aws_instance.production.public_ip}"]
-}
-
-resource "aws_route53_record" "ajl-bocoup-org_A_ajl-staging-bocoup-org" {
-  zone_id = "${data.terraform_remote_state.foundation.domain_zone_id}"
-  type = "A"
-  name = "ajl-staging"
+  name = "staging"
   ttl = "1"
   records = ["${aws_instance.staging.public_ip}"]
 }


### PR DESCRIPTION
Previously, the AJL staging server was only accessible through
`staging.bocoup.org. Introduce a new subdomain for ajl.ai,
`staging.aji.ai`.